### PR TITLE
Patch/make es5 compatible

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,12 +24,12 @@ module.exports = function circleToPolygon(center, radius, numberOfSegments) {
   var n = numberOfSegments ? numberOfSegments : 32;
   var flatCoordinates = [];
   var coordinates = [];
-  for (let i = 0; i < n; ++i) {
+  for (var i = 0; i < n; ++i) {
     flatCoordinates.push.apply(flatCoordinates, offset(center, radius, 2 * Math.PI * i / n));
   }
   flatCoordinates.push(flatCoordinates[0], flatCoordinates[1]);
 
-  for (let i = 0, j = 0; j < flatCoordinates.length; j += 2) {
+  for (var i = 0, j = 0; j < flatCoordinates.length; j += 2) {
     coordinates[i++] = flatCoordinates.slice(j, j + 2);
   }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "circle-to-polygon",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Receives a Coordinate, a Radius and a Number of edges and aproximates a circle by creating a polygon that fills its area",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Using non-transpiled dependencies causes problems for users of `create-react-app` (https://github.com/facebookincubator/create-react-app/issues/1125). 